### PR TITLE
fix: set Docker Compose project name to 'localai'

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ python3 start_services.py --profile none        # Mac (Ollama lokal)
 
 ## 📋 Changelog
 
+### 2026-04 – Fix: Docker Compose Projektname
+
+| Was | Details |
+|-----|---------|
+| `docker-compose.yml` | `name: localai` gesetzt – Projektname ist jetzt fest definiert, kein `-p localai` mehr nötig |
+
+---
+
 ### 2026-04 – TTS Service: Voice Cloning & Video Dubbing
 
 | Was | Details |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: localai
+
 include:
   - ./supabase/docker/docker-compose.yml
 

--- a/docs/18_tts_service.md
+++ b/docs/18_tts_service.md
@@ -46,7 +46,7 @@ OLLAMA_TRANSLATE_MODEL=qwen2.5:7b-instruct-q4_K_M
 ### 3. Stack starten
 
 ```bash
-docker compose up tts-service -d
+docker compose up -d tts-service
 ```
 
 > Beim ersten Start lädt OmniVoice das Modell (~2 GB) von HuggingFace.


### PR DESCRIPTION
Adds `name: localai` to docker-compose.yml so the project name is always defined — no more wrong network when starting services without explicit `-p localai`. Also fixes docker compose command order in docs/18_tts_service.md.