### PR TITLE
chore(deps): bump pillow and python-multipart

### DIFF
--- a/ocr-service/requirements.txt
+++ b/ocr-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
-python-multipart==0.0.22
+python-multipart==0.0.26
 Pillow>=10.2.0
 opencv-python>=4.9.0.80
 numpy>=1.24.3

--- a/python-nlp-service/requirements.txt
+++ b/python-nlp-service/requirements.txt
@@ -27,7 +27,7 @@ neo4j==5.27.0
 
 # Dokument- und PDF-Verarbeitung
 PyMuPDF==1.24.3           # PDF-Text-Extraktion und PDF→PNG (fitz)
-Pillow==12.1.1            # Bildverarbeitung für OCR-Vorbereitung
+Pillow==12.2.0            # Bildverarbeitung für OCR-Vorbereitung
 
 # System Dependencies werden im Dockerfile installiert:
 # - curl (für HEALTHCHECK)

--- a/tts-service/requirements.txt
+++ b/tts-service/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
-python-multipart==0.0.22
+python-multipart==0.0.26
 pydantic>=2.5.0
 aiofiles>=23.2.1
 httpx>=0.25.0


### PR DESCRIPTION
Supersedes the stale Dependabot PR #44 against the current main branch.

Updates:
- ocr-service: python-multipart 0.0.22 -> 0.0.26
- tts-service: python-multipart 0.0.22 -> 0.0.26
- python-nlp-service: Pillow 12.1.1 -> 12.2.0

Validation:
- pytest ocr-service/tests/test_app.py
- NEO4J_AUTH=test/test pytest python-nlp-service/tests/test_app.py

Note:
- The combined pytest invocation fails because both services use the same test module basename (test_app.py), so they were executed separately.