### PR TITLE
fix(ocr-service): remove surya-ocr to resolve Pillow 12 conflict

### DIFF
--- a/ocr-service/requirements.txt
+++ b/ocr-service/requirements.txt
@@ -18,9 +18,6 @@ sentencepiece>=0.1.99
 protobuf>=4.25.0
 tiktoken>=0.5.0
 
-# Surya OCR - High-quality fallback OCR
-surya-ocr>=0.4.0
-
 # Tesseract OCR - Backup OCR engine
 pytesseract>=0.3.10
 


### PR DESCRIPTION
## Problem

Der `ocr-service`-Build schlug fehl weil `surya-ocr>=0.4.0` (inkl. aktuellste Version 0.20.0) `Pillow<11.0.0` erfordert — im Widerspruch zu dem in PR #36 gesetzten Security-Fix `Pillow>=12.2.0`.

## Lösung

`surya-ocr` aus `requirements.txt` entfernt. Der Import ist bereits durch einen `try/except`-Block abgesichert (`SURYA_AVAILABLE = False` bei fehlendem Paket) — der Service läuft weiter mit TrOCR + Tesseract als OCR-Engines.

## Test

```bash
docker compose build --no-cache ocr-service  # baut erfolgreich
docker compose up -d ocr-service             # Status: healthy
```